### PR TITLE
URL Identifiers now include the wiki origin

### DIFF
--- a/client/frame.js
+++ b/client/frame.js
@@ -61,6 +61,7 @@
     return {
       pageKey: $page.data("key"),
       itemId: item.id,
+      origin: window.origin,
       site: $page.data("site") || window.location.host,
       slug: $page.attr("id"),
       title: $page.data("data").title
@@ -223,8 +224,7 @@
     case "sendFrameContext":
       event.source.postMessage({
         action: "frameContext",
-        site: $page.data("site") || window.location.host,
-        slug: $page.attr("id"),
+        ...identifiers($item, $item.data()),
         item: $item.data("item"),
         page: $page.data("data")
       }, "*")

--- a/pages/about-frame-integrations
+++ b/pages/about-frame-integrations
@@ -74,7 +74,7 @@
     {
       "type": "code",
       "id": "a6dfb82dc84c3ac9",
-      "text": "window.addEventListener(\"message\", handleFrameContext)\nfunction handleFrameContext ({data}) {\n  console.log(\"message received\", data)\n  if (data.action == \"frameContext\") {\n    window.removeEventListener(\n      \"message\", handleFrameContext)\n    const {site, slug, item, \n      page: {title, story}} = data\n    const items = story.reduce((acc, {type}) => {\n      acc[type] = (acc[type]||0)+1\n      return acc\n    }, {})\n    console.log({title, items})\n  }\n}\n\nwindow.addEventListener(\n  \"DOMContentLoaded\",\n  () => window.parent.postMessage({\n    action: \"sendFrameContext\"\n  }, \"*\")\n)"
+      "text": "window.addEventListener(\"message\", handleFrameContext)\nfunction handleFrameContext ({data}) {\n  console.log(\"message received\", data)\n  if (data.action == \"frameContext\") {\n    window.removeEventListener(\n      \"message\", handleFrameContext)\n    const {pageKey, itemId, origin, site, slug, item, \n      page: {title, story}} = data\n    const items = story.reduce((acc, {type}) => {\n      acc[type] = (acc[type]||0)+1\n      return acc\n    }, {})\n    console.log({title, items})\n  }\n}\n\nwindow.addEventListener(\n  \"DOMContentLoaded\",\n  () => window.parent.postMessage({\n    action: \"sendFrameContext\"\n  }, \"*\")\n)"
     },
     {
       "type": "markdown",
@@ -109,7 +109,7 @@
     {
       "type": "code",
       "id": "dacc2f7fdffebb9e",
-      "text": "const identifiers = Object.fromEntries(\n  new URLSearchParams(\n    window.location.hash.substr(1)\n  ).entries()\n)\n\nconsole.log({\n  title: identifiers.title,\n  site: identifiers.site,\n  slug: identifiers.slug,\n  pageKey: identifiers.pageKey,\n  itemId: identifiers.itemId\n})"
+      "text": "const identifiers = Object.fromEntries(\n  new URLSearchParams(\n    window.location.hash.substr(1)\n  ).entries()\n)\n\nconsole.log({\n  origin: identifiers.origin,\n  title: identifiers.title,\n  site: identifiers.site,\n  slug: identifiers.slug,\n  pageKey: identifiers.pageKey,\n  itemId: identifiers.itemId\n})"
     },
     {
       "type": "markdown",
@@ -985,6 +985,36 @@
         "text": "PLUGIN frame/integrations.html"
       },
       "date": 1631372547216
+    },
+    {
+      "type": "edit",
+      "id": "dacc2f7fdffebb9e",
+      "item": {
+        "type": "code",
+        "id": "dacc2f7fdffebb9e",
+        "text": "const identifiers = Object.fromEntries(\n  new URLSearchParams(\n    window.location.hash.substr(1)\n  ).entries()\n)\n\nconsole.log({\n  origin: identifiers.origin,\n  title: identifiers.title,\n  site: identifiers.site,\n  slug: identifiers.slug,\n  pageKey: identifiers.pageKey,\n  itemId: identifiers.itemId\n})"
+      },
+      "date": 1636212441494
+    },
+    {
+      "type": "edit",
+      "id": "a6dfb82dc84c3ac9",
+      "item": {
+        "type": "code",
+        "id": "a6dfb82dc84c3ac9",
+        "text": "window.addEventListener(\"message\", handleFrameContext)\nfunction handleFrameContext ({data}) {\n  console.log(\"message received\", data)\n  if (data.action == \"frameContext\") {\n    window.removeEventListener(\n      \"message\", handleFrameContext)\n    const {origin, site, slug, item, \n      page: {title, story}} = data\n    const items = story.reduce((acc, {type}) => {\n      acc[type] = (acc[type]||0)+1\n      return acc\n    }, {})\n    console.log({title, items})\n  }\n}\n\nwindow.addEventListener(\n  \"DOMContentLoaded\",\n  () => window.parent.postMessage({\n    action: \"sendFrameContext\"\n  }, \"*\")\n)"
+      },
+      "date": 1636212493206
+    },
+    {
+      "type": "edit",
+      "id": "a6dfb82dc84c3ac9",
+      "item": {
+        "type": "code",
+        "id": "a6dfb82dc84c3ac9",
+        "text": "window.addEventListener(\"message\", handleFrameContext)\nfunction handleFrameContext ({data}) {\n  console.log(\"message received\", data)\n  if (data.action == \"frameContext\") {\n    window.removeEventListener(\n      \"message\", handleFrameContext)\n    const {pageKey, itemId, origin, site, slug, item, \n      page: {title, story}} = data\n    const items = story.reduce((acc, {type}) => {\n      acc[type] = (acc[type]||0)+1\n      return acc\n    }, {})\n    console.log({title, items})\n  }\n}\n\nwindow.addEventListener(\n  \"DOMContentLoaded\",\n  () => window.parent.postMessage({\n    action: \"sendFrameContext\"\n  }, \"*\")\n)"
+      },
+      "date": 1636212550420
     }
   ]
 }


### PR DESCRIPTION
Ward has been experimenting with interactions between html scripts
inside frames and files inside of assets. The experiments reveal cases
where the html script programmer needs information about three
different web contexts:

1) the script itself can be hosted under one domain name,

2) the frame item on a wiki page under another domain name, and

3) the wiki origin holding a lineup of pages under a third domain name.

item 1 can be gotten from window.location
item 2 is in the "site"
item 3 is new and given in the "origin"