### PR TITLE
HTML scripts from foreign origins can now access cookies & storage

### DIFF
--- a/client/frame.js
+++ b/client/frame.js
@@ -76,11 +76,22 @@
     }
   }
 
+  function sandboxFor(url) {
+    if (url.startsWith('//')) {
+      const {protocol} = new URL(window.origin)
+      url = `${protocol}${url}`
+    }
+    return (window.origin == new URL(url).origin)
+          ? 'allow-scripts allow-downloads allow-forms'
+          : 'allow-scripts allow-downloads allow-forms allow-same-origin'
+  }
+
   function drawFrame($item, item, parsed) {
     const params = new URLSearchParams(identifiers($item, item)).toString()
     const frame = document.createElement('iframe')
+    const sandbox = sandboxFor(parsed.src)
     for (let [attr, value] of [
-      ['sandbox', 'allow-scripts allow-downloads allow-forms'],
+      ['sandbox', sandbox],
       ['width', '100%'],
       ['style', 'border: none;'],
       ['src', `${parsed.src}#${params}`]
@@ -295,7 +306,9 @@
 
   if (typeof module !== "undefined" && module !== null) {
     wiki = {resolveLinks: (text, escape) => escape(text)}
-    module.exports = {expand, parse, publishSourceData, triggerThumb}
+    module.exports = {
+      expand, parse, publishSourceData, triggerThumb, sandboxFor
+    }
   }
 
 }).call(this)

--- a/client/frame.js
+++ b/client/frame.js
@@ -21,7 +21,15 @@
       const hostname = matchData[1]
       return {src, hostname}
     } else if (matchData = line.match(/^PLUGIN (.+)$/)) {
-      return {src: `/plugins/${matchData[1]}`}
+      try {
+        src = new URL(`/plugins/${matchData[1]}`, window.document.baseURI).toString()
+        return {src}
+      } catch (error) {
+        if (! error instanceof TypeError) {
+          throw(error)
+        }
+        return {src, error}
+      }
     } else {
       const error = 'Error: frame src must include domain name'
       return {src, error}

--- a/test/test.js
+++ b/test/test.js
@@ -51,13 +51,25 @@
         expect(result)
           .not.to.have.property('error');
       })
-      it('accepts PLUGIN keyword', () => {
-        const result = frame.parse('PLUGIN frame/integrations.html');
-        expect(result)
-          .to.have.property('src', '/plugins/frame/integrations.html');
-        expect(result)
-          .not.to.have.property('error');
-      });
+      context("PLUGIN keyword", () => {
+        beforeEach(() => {
+          window = {document: {baseURI: "https://example.com"}}
+        })
+        it('is accepted', () => {
+          const result = frame.parse('PLUGIN frame/integrations.html');
+          expect(result)
+            .to.have.property('src', 'https://example.com/plugins/frame/integrations.html');
+          expect(result)
+            .not.to.have.property('error');
+        });
+        it('encodes invalid characters in PLUGIN', () => {
+          const result = frame.parse('PLUGIN frame/invalid{characters}');
+          expect(result)
+            .to.have.property('src', 'https://example.com/plugins/frame/invalid%7Bcharacters%7D');
+          expect(result)
+            .not.to.have.property('error');
+        });
+      })
       it('rejects missing domain', () => {
         const result = frame.parse('/some/path.html');
         expect(result)

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,37 @@
       });
     });
 
+    describe('sandboxFor', () => {
+      describe('when origin differs from frame src', () => {
+        beforeEach(() => {
+          window = {origin: 'http://wiki.example.com'}
+        })
+        it('permits allow-same-origin', () => {
+          const result = frame.sandboxFor('http://frame.example.com/')
+          expect(result).to.contain('allow-same-origin')
+        })
+      })
+      describe('when origin equals frame src', () => {
+        beforeEach(() => {
+          window = {origin: 'http://wiki.example.com'}
+        })
+        it('excludes allow-same-origin', () => {
+          const result = frame.sandboxFor('http://wiki.example.com/')
+          expect(result).to.not.contain('allow-same-origin')
+        })
+      })
+      describe('when frame src is protocol-relative', () => {
+        beforeEach(() => {
+          window = {origin: 'http://wiki.example.com'}
+        })
+        it('does not raise errors', () => {
+          expect(frame.sandboxFor)
+            .withArgs('//frame.example.com')
+            .to.not.throwException()
+        })
+      })
+    })
+
     describe('SOURCE', () => {
       it('is recognized', () => {
         const result = frame.parse("//example.com\nSOURCE radar")


### PR DESCRIPTION
Fixing the sandbox security broke some existing usages of frames:

For example ObservableHQ has a d3 example named voronoi.update: https://observablehq.com/embed/@d3/voronoi-update?cells=chart

The embedded notebook fails to render here: http://wiki.dbbs.co/sci-foo-lightning-talks.html. Similarly, the youtube deep link to Alan Kay's drive-a-car example fails on this page: http://wiki.dbbs.co/back-to-the-future-of-software.html

With this update, if the frame src is a different origin from the wiki, then allow-same-origin is permitted, opening access to cookies and browser storage.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe

    When the embedded document has the same origin as the embedding
    page, it is strongly discouraged to use both allow-scripts and
    allow-same-origin, as that lets the embedded document remove the
    sandbox attribute — making it no more secure than not using the
    sandbox attribute at all.

Therefore we continue to forbid allow-same-origin when the frame src matches the wiki origin.