### PR TITLE
Update frame.js

### DIFF
--- a/client/frame.js
+++ b/client/frame.js
@@ -1,6 +1,6 @@
 (function() {
 
-  const resizeFudge = 30
+  const resizeFudge = 40
   const defaultHeight = 150 - resizeFudge
 
   function expand(text) {


### PR DESCRIPTION
This makes the frame item with the #miro link on [this page](http://robert.wiki.openlearning.cc/import-miro-graphs.html) not show an internal scroll bar when the frame HEIGHT parameter is 0. I was trying to make the frame for a simple link as small as possible. I also notice that frames that are beside each other on the page like the one above just sort of blend together and look like one larger frame. I also noticed an empty <p></p> for each frame items on the page after the iframe element in the HTML, not sure what's adding that.