### PR TITLE
add checks that message is for us

### DIFF
--- a/client/frame.js
+++ b/client/frame.js
@@ -227,7 +227,7 @@
     // events from iframes don't have an opener
     // ensure that the iframe is one of ours
     if (event.source.opener ||
-        !$("iframe").filter((i,el) => el.contentWindow === event.source).parents(".item").hasClass("frame")) { 
+        !$(".item.frame iframe").filter((i,el) => el.contentWindow === event.source)) { 
       if (wiki.debug) {console.log('frameListener - not for us', {event})}
       return
     }

--- a/client/frame.js
+++ b/client/frame.js
@@ -223,6 +223,16 @@
   }
 
   function frameListener(event) {
+    // is this message for us?
+    // events from iframes don't have an opener
+    // ensure that the iframe is one of ours
+    if (event.source.opener ||
+        !$("iframe").filter((i,el) => el.contentWindow === event.source).parents(".item").hasClass("frame")) { 
+      if (wiki.debug) {console.log('frameListener - not for us', {event})}
+      return
+    }
+    if (wiki.debug) {console.log('frameListener - ours', {event})}
+    
     const {data} = event;
     const {action, keepLineup=false, pageKey=null, page=null, pages={},
            title=null, site=null} = data;


### PR DESCRIPTION
First of a series of updates replacing jQuery UI Dialog.

Here a check is added to filter out message events that are not from iframes that are not part of a frame plugin.